### PR TITLE
[mpact][benchmark] check output type

### DIFF
--- a/benchmark/python/utils/benchmark_utils.py
+++ b/benchmark/python/utils/benchmark_utils.py
@@ -136,12 +136,14 @@ def run_benchmark(
                         output.append(
                             torch.sparse_csr_tensor(*sp_out, size=dense_out.shape)
                         )
-                        # Check MPACT and torch eager both return sparse csr output.
+                        # Check MPACT and torch eager both return sparse csr output
+                        # only when torch sparse eager has been run.
                         if output_type:
                             assert output_type == torch.sparse_csr
                     else:
                         output.append(torch.from_numpy(sp_out))
-                        # Check MPACT and torch eager both return dense output.
+                        # Check MPACT and torch eager both return dense output
+                        # only when torch sparse eager has been run.
                         if output_type:
                             assert output_type == torch.strided
                     invoker, f = mpact_jit_compile(torch_net, *sparse_inputs)

--- a/benchmark/python/utils/benchmark_utils.py
+++ b/benchmark/python/utils/benchmark_utils.py
@@ -138,12 +138,12 @@ def run_benchmark(
                         )
                         # Check MPACT and torch eager both return sparse csr output.
                         if output_type:
-                            assert(output_type == torch.sparse_csr)
+                            assert output_type == torch.sparse_csr
                     else:
                         output.append(torch.from_numpy(sp_out))
                         # Check MPACT and torch eager both return dense output.
                         if output_type:
-                            assert(output_type == torch.strided)
+                            assert output_type == torch.strided
                     invoker, f = mpact_jit_compile(torch_net, *sparse_inputs)
                     compile_time_results.append(
                         timer(


### PR DESCRIPTION
Make sure mpact sparse return the same output format as torch eager mode.