### PR TITLE
Revert "Update build-and-test.yml"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,8 @@
 name: Build and test
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Reverts MPACT-ORG/mpact-compiler#48
Ccache will restore from pushing to main. Because it's disabled since the bump, all the subsequent runs take a long time to build as it's using an old cache before the bump. 