### PR TITLE
[mpact][profiler] Add utils for profiling Python programs and torch ops

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,4 +28,10 @@ python path/to/the/kernels_benchmark.py --benchmark-filter=add
 ### Profiler
 
 Utils for profiling python scripts and pytorch models could be found in
-benchmark/python/utils/profiler.py.
+`benchmark/python/utils/profiler.py`.
+
+To run the profiling example, use the following command:
+
+```shell
+python benchmark/python/utils/profiler.py
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,3 +24,8 @@ you can use `--benchmark-filter` flag like the following example:
 ```shell
 python path/to/the/kernels_benchmark.py --benchmark-filter=add
 ```
+
+### Profiler
+
+Utils for profiling python scripts and pytorch models could be found in
+benchmark/python/utils/profiler.py.

--- a/benchmark/python/utils/profiler.py
+++ b/benchmark/python/utils/profiler.py
@@ -1,0 +1,70 @@
+import torch
+import cProfile
+from pstats import Stats
+
+
+def profile_torch(func, args, row_limit=10,
+                  save_output=False, func_name=None,
+                  file_name="trace"):
+    """Use PyTorch's profiler to profile torch ops.
+
+    To see the graph: upload trace.json to chrome://tracing
+
+    More details about PyTorch profiler:
+    https://pytorch.org/tutorials/recipes/recipes/profiler_recipe.html
+    """
+    func_name = func_name if func_name else func.__name__
+    with torch.profiler.profile() as prof:
+        with torch.profiler.record_function(func_name):
+            func(*args)
+    print(prof.key_averages().table(sort_by="cpu_time_total",
+                                    row_limit=row_limit))
+    if save_output:
+        prof.export_chrome_trace(f"{file_name}.json")
+
+
+def profile_python(func, args, row_limit=10, save_output=False,
+                   file_name="stats"):
+    """Use cProfile to profile python function calls.
+
+    To see the graph, run the following commands:
+    1. python -m pip install snakeviz
+    2. snakeviz stats.prof
+    """
+    pr = cProfile.Profile()
+    pr.enable()
+    func(*args)
+    pr.disable()
+    stats = Stats(pr)
+    stats.sort_stats('tottime').print_stats(row_limit)
+    if save_output:
+        pr.dump_stats(f"{file_name}.prof")
+
+
+if __name__ == "__main__":
+    # Example usage of the profiler.
+    from mpact.models.kernels import MMNet
+    from mpact_benchmark.utils.tensor_generator import generate_tensor
+    from mpact.mpactbackend import mpact_jit
+
+
+    # Generate input tensors.
+    dense_tensor1 = generate_tensor(seed=0, shape=(32, 32),
+                                    sparsity=0.8)
+    dense_tensor2 = generate_tensor(seed=1, shape=(32, 32),
+                                    sparsity=0.8)
+    sparse_tensor1 = dense_tensor1.to_sparse_csr()
+    sparse_tensor2 = dense_tensor2.to_sparse_csr()
+
+    # Profile with PyTorch profiler for torch operators.
+    # MPACT sparse.
+    profile_torch(mpact_jit, (MMNet(), sparse_tensor1, sparse_tensor2))
+    # Torch sparse.
+    profile_torch(MMNet(), (sparse_tensor1, sparse_tensor2),
+                  func_name="sparsexsparse matmul")
+
+    # Profile with cProfile for Python function calls.
+    # MPACT sparse.
+    profile_python(mpact_jit, (MMNet(), sparse_tensor1, sparse_tensor2))
+    # Torch sparse.
+    profile_python(MMNet(), (sparse_tensor1, sparse_tensor2))

--- a/benchmark/python/utils/profiler.py
+++ b/benchmark/python/utils/profiler.py
@@ -3,9 +3,9 @@ import cProfile
 from pstats import Stats
 
 
-def profile_torch(func, args, row_limit=10,
-                  save_output=False, func_name=None,
-                  file_name="trace"):
+def profile_torch(
+    func, args, row_limit=10, save_output=False, func_name=None, file_name="trace"
+):
     """Use PyTorch's profiler to profile torch ops.
 
     To see the graph: upload trace.json to chrome://tracing
@@ -17,14 +17,12 @@ def profile_torch(func, args, row_limit=10,
     with torch.profiler.profile() as prof:
         with torch.profiler.record_function(func_name):
             func(*args)
-    print(prof.key_averages().table(sort_by="cpu_time_total",
-                                    row_limit=row_limit))
+    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=row_limit))
     if save_output:
         prof.export_chrome_trace(f"{file_name}.json")
 
 
-def profile_python(func, args, row_limit=10, save_output=False,
-                   file_name="stats"):
+def profile_python(func, args, row_limit=10, save_output=False, file_name="stats"):
     """Use cProfile to profile python function calls.
 
     To see the graph, run the following commands:
@@ -36,7 +34,7 @@ def profile_python(func, args, row_limit=10, save_output=False,
     func(*args)
     pr.disable()
     stats = Stats(pr)
-    stats.sort_stats('tottime').print_stats(row_limit)
+    stats.sort_stats("tottime").print_stats(row_limit)
     if save_output:
         pr.dump_stats(f"{file_name}.prof")
 
@@ -47,12 +45,9 @@ if __name__ == "__main__":
     from mpact_benchmark.utils.tensor_generator import generate_tensor
     from mpact.mpactbackend import mpact_jit
 
-
     # Generate input tensors.
-    dense_tensor1 = generate_tensor(seed=0, shape=(32, 32),
-                                    sparsity=0.8)
-    dense_tensor2 = generate_tensor(seed=1, shape=(32, 32),
-                                    sparsity=0.8)
+    dense_tensor1 = generate_tensor(seed=0, shape=(32, 32), sparsity=0.8)
+    dense_tensor2 = generate_tensor(seed=1, shape=(32, 32), sparsity=0.8)
     sparse_tensor1 = dense_tensor1.to_sparse_csr()
     sparse_tensor2 = dense_tensor2.to_sparse_csr()
 
@@ -60,8 +55,9 @@ if __name__ == "__main__":
     # MPACT sparse.
     profile_torch(mpact_jit, (MMNet(), sparse_tensor1, sparse_tensor2))
     # Torch sparse.
-    profile_torch(MMNet(), (sparse_tensor1, sparse_tensor2),
-                  func_name="sparsexsparse matmul")
+    profile_torch(
+        MMNet(), (sparse_tensor1, sparse_tensor2), func_name="sparsexsparse matmul"
+    )
 
     # Profile with cProfile for Python function calls.
     # MPACT sparse.


### PR DESCRIPTION
**Example graph output:**

PyTorch profiler with chrome tracing:
![7ZnCnLVYiERQBDN](https://github.com/MPACT-ORG/mpact-compiler/assets/107574043/3be917c6-2958-4962-b310-c72e6ff097fb)

cProfile with Snakeviz:
![3ufAeiZ6VZ9kduT](https://github.com/MPACT-ORG/mpact-compiler/assets/107574043/339ed1c0-5cde-4289-9d05-ea887a61db04)

**Example text output:**
```
(mpact_venv) yinyingli@yyli:~/mpact/mpact-compiler$ python /usr/local/google/home/yinyingli/mpact/mpact-compiler/benchmark/python/utils/profiler.py
/usr/local/google/home/yinyingli/mpact/mpact-compiler/benchmark/python/utils/profiler.py:48: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at ../aten/src/ATen/SparseCsrTensorImpl.cpp:53.)
  sparse_tensor1 = dense_tensor1.to_sparse_csr()

PyTorch Profiler:

--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                              Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                         mpact_jit        90.31%     542.227ms       100.00%     600.402ms     600.402ms             1  
     create_aot_dispatcher_function (dynamo_timed)         2.21%      13.278ms         4.79%      28.759ms      14.380ms             2  
    _compile.<locals>.compile_inner (dynamo_timed)         4.49%      26.931ms         4.67%      28.015ms      28.015ms             1  
                                  aten::lift_fresh         1.12%       6.699ms         1.26%       7.546ms     145.111us            52  
                                      aten::detach         0.25%       1.499ms         0.89%       5.369ms      68.837us            78  
                                          aten::mm         0.58%       3.460ms         0.76%       4.557ms     506.305us             9  
                                            detach         0.39%       2.347ms         0.60%       3.582ms      83.300us            43  
                             Torch-Compiled Region         0.10%     622.568us         0.13%     785.849us     785.849us             1  
                                       aten::clone         0.05%     284.027us         0.12%     707.501us      20.809us            34  
                               aten::empty_strided         0.11%     682.793us         0.11%     682.793us       8.033us            85  
--------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 600.402ms

------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                      Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                               aten::addmm        83.17%       1.616ms       185.12%       3.597ms       1.799ms             2  
                      sparsexsparse matmul         4.42%      85.949us       100.00%       1.943ms       1.943ms             1  
                                  aten::mm         1.09%      21.178us        95.58%       1.857ms       1.857ms             1  
                               aten::copy_         2.67%      51.798us         3.81%      74.131us       4.633us            16  
                                aten::add_         0.19%       3.600us         3.66%      71.140us      71.140us             1  
                                 aten::add         0.99%      19.160us         3.48%      67.540us      67.540us             1  
                               aten::zeros         0.79%      15.331us         1.95%      37.920us      18.960us             2  
                   aten::resize_as_sparse_         0.49%       9.498us         1.77%      34.380us      34.380us             1  
                                  aten::to         0.21%       4.160us         1.51%      29.249us       4.875us             6  
                            aten::_to_copy         0.46%       8.862us         1.29%      25.089us       4.181us             6  
------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 1.943ms


cProfile:

         88170 function calls (84738 primitive calls) in 0.177 seconds

   Ordered by: internal time
   List reduced from 2060 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.034    0.034    0.034    0.034 {built-in method mpact._mlir_libs._mlirExecutionEngine.raw_lookup}
        2    0.033    0.017    0.033    0.017 {built-in method mpact._mlir_libs._mlir.passmanager.run}
        1    0.022    0.022    0.022    0.022 /usr/local/google/home/yinyingli/mpact/mpact-compiler/build/tools/mpact/python_packages/mpact/mpact/mpactbackend.py:165(__init__)
        1    0.004    0.004    0.004    0.004 {built-in method mpact._mlir_libs._mlir.ir.load_all_available_dialects}
        1    0.002    0.002    0.179    0.179 /usr/local/google/home/yinyingli/mpact/mpact-compiler/build/tools/mpact/python_packages/mpact/mpact/mpactbackend.py:525(mpact_jit)
        1    0.002    0.002    0.037    0.037 /usr/local/google/home/yinyingli/mpact/mpact-compiler/build/tools/mpact/python_packages/mpact/mpact/execution_engine.py:26(invoke)
11299/11133    0.001    0.000    0.002    0.000 {built-in method builtins.isinstance}
       34    0.001    0.000    0.001    0.000 {built-in method builtins.compile}
     1244    0.001    0.000    0.001    0.000 {built-in method builtins.setattr}
       26    0.001    0.000    0.012    0.000 {built-in method torch.tensor}


         6 function calls in 0.000 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.000    0.000 {built-in method torch.mm}
        1    0.000    0.000    0.000    0.000 /usr/local/google/home/yinyingli/mpact/mpact-compiler/mpact_venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1554(_call_impl)
        1    0.000    0.000    0.000    0.000 {built-in method torch._C._get_tracing_state}
        1    0.000    0.000    0.000    0.000 /usr/local/google/home/yinyingli/mpact/mpact-compiler/build/tools/mpact/python_packages/mpact/mpact/models/kernels.py:10(forward)
        1    0.000    0.000    0.000    0.000 /usr/local/google/home/yinyingli/mpact/mpact-compiler/mpact_venv/lib/python3.11/site-packages/torch/nn/modules/module.py:1548(_wrapped_call_impl)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

```