### PR TITLE
[WIP][MPACT] add parallelization with OpenMP to MPACT

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,9 @@ add_lit_testsuite(check-mpact "Running the MPACT regression tests"
         )
 set_target_properties(check-mpact PROPERTIES FOLDER "Tests")
 
+# TODO: find omp library.
+find_package(OpenMP REQUIRED)
+add_compile_options(${OpenMP_CXX_FLAGS})
+# target_link_libraries(check-mpact OpenMP::OpenMP_CXX)
+
 add_lit_testsuites(MPACT ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TORCH_MLIR_TEST_DEPENDS})

--- a/test/python/parallel.py
+++ b/test/python/parallel.py
@@ -1,0 +1,40 @@
+# RUN: %PYTHON -s %s 2>&1 | FileCheck %s
+
+import gc
+import sys
+import torch
+import numpy as np
+
+from mpact.mpactbackend import mpact_jit
+
+from mpact.models.kernels import MMNet
+
+
+def run_test(f, *args, **kwargs):
+    print("TEST:", f.__name__, file=sys.stderr)
+    f(*args, **kwargs)
+    gc.collect()
+
+net = MMNet()
+
+# Construct dense and sparse matrices.
+X = torch.arange(0, 16, dtype=torch.float32).view(4, 4)
+Y = torch.arange(16, 32, dtype=torch.float32).view(4, 4)
+A = torch.tensor(
+    [
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 2.0],
+        [0.0, 0.0, 0.0, 0.0],
+        [3.0, 0.0, 0.0, 0.0],
+    ],
+    dtype=torch.float32,
+)
+S = A.to_sparse_csr()
+
+# Run it with MPACT.
+# TODO: enable the check test.
+# C-HECK: omp.parallel
+# CHECK: openmp
+run_test(mpact_jit, net, X, Y,
+         parallel="any-storage-any-loop", enable_ir_printing=True,
+         num_threads=10)


### PR DESCRIPTION
1. Add omp passes to the pipeline.
2. Add parallel strategy option and omp thread option.
3. Enable printing IR for testing.


TODO:
1. MLIR PR approval and MLIR bump.
2. Make sure the openmp lib can be found.